### PR TITLE
Add asterisk

### DIFF
--- a/docs/source/usage/use-cases.rst
+++ b/docs/source/usage/use-cases.rst
@@ -24,7 +24,7 @@ argument, while using the basic OS functions. You can write this to a csv file t
 
 .. code-block:: console
 
-    $ target-query targets/ -f hostname,domain,OS,version,ips --cmdb -d ";" > docs/CMDB.csv
+    $ target-query targets/* -f hostname,domain,OS,version,ips --cmdb -d ";" > docs/CMDB.csv
 
 Pushing query results to a search platform
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Is it intended that the asterisk is not used in this command? Because it misses the target `SCHARDT`. Or is there another way to do this?

```bash
target-query targets/ -f hostname -q
<Target targets/MSEDGEWIN10_20220708124036.tar> MSEDGEWIN10
<Target targets/linux> kali

target-query targets/* -f hostname -q
<Target targets/MSEDGEWIN10_20220708124036.tar> MSEDGEWIN10
<Target targets/SCHARDT.001> N-1A9ODN6ZXK4LQ
<Target targets/SCHARDT.002> N-1A9ODN6ZXK4LQ
<Target targets/SCHARDT.003> N-1A9ODN6ZXK4LQ
<Target targets/SCHARDT.004> N-1A9ODN6ZXK4LQ
<Target targets/SCHARDT.005> N-1A9ODN6ZXK4LQ
<Target targets/SCHARDT.006> N-1A9ODN6ZXK4LQ
<Target targets/SCHARDT.007> N-1A9ODN6ZXK4LQ
<Target targets/SCHARDT.008> N-1A9ODN6ZXK4LQ
<Target targets/linux> kali
```