### PR TITLE
Add a Resources section to the documentation

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -19,3 +19,7 @@
 table.docutils {
     width: 99%;
 }
+
+table.left-text-align th {
+    text-align: left;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,8 +46,11 @@ extensions = [
     "sphinx_argparse_cli",
     "sphinx_copybutton",
     "sphinx_design",
-    "autoapi.extension",
 ]
+
+# Allow disabling of time consuming autoapi generation
+if not os.getenv("NO_AUTOAPI"):
+    extensions.append("autoapi.extension")
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,8 +16,9 @@ plugins that work quickly and easily on a large range of evidence formats. More 
 experience can also leverage Dissect`s full capabilities by creating new tools and plugins using the various Dissect
 APIs and parsers.
 
-Read more about what Dissect is and how it works at :doc:`/overview/index`, or `watch an introductory video
-<https://www.youtube.com/watch?v=A2e203LizAM>`_ by `13Cubed <https://www.youtube.com/@13Cubed>`_.
+Read more about what Dissect is and how it works at :doc:`/overview/index`, or check out what others
+have written about Dissect in :doc:`/resources/dissect-in-action`.
+
 
 Getting Started
 ---------------
@@ -122,6 +123,12 @@ For more information about what Dissect is and how it works, read on at :doc:`/o
     /contributing/developing
     /contributing/style-guide
     License </license>
+
+.. toctree::
+    :caption: Resources
+    :hidden:
+
+    /resources/dissect-in-action
 
 .. toctree::
     :caption: Links

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,8 +16,10 @@ plugins that work quickly and easily on a large range of evidence formats. More 
 experience can also leverage Dissect`s full capabilities by creating new tools and plugins using the various Dissect
 APIs and parsers.
 
-Read more about what Dissect is and how it works at :doc:`/overview/index`, or check out what others
-have written about Dissect in :doc:`/resources/dissect-in-action`.
+
+.. note ::
+    Read more about what Dissect is and how it works at :doc:`/overview/index` or check out what others
+    have written about Dissect in :doc:`/resources/dissect-in-action`.
 
 
 Getting Started
@@ -129,6 +131,7 @@ For more information about what Dissect is and how it works, read on at :doc:`/o
     :hidden:
 
     /resources/dissect-in-action
+    /resources/talks-and-conferences
 
 .. toctree::
     :caption: Links

--- a/docs/source/resources/dissect-in-action.rst
+++ b/docs/source/resources/dissect-in-action.rst
@@ -1,0 +1,65 @@
+Dissect in Action
+=================
+
+On this page you will find references to articles or videos made by community users of Dissect.
+
+Since Dissect was launched, we have seen numerous researchers, forensic investigators
+and enthusiasts write or present about Dissect. Some of them have written about how
+Dissect has helped in solving their problems, while others have created their own tutorials 
+and starter guides.
+
+We encourage you to check out these articles for inspiration on how Dissect can help you solve your problems.
+
+.. note::
+    Have you written an article which you think should be included here? 
+    Please send a link to your article to dissect@fox-it.com and we might include it here in the future!
+
+Dissect solving problems
+------------------------
+
+The table below contains references to articles where Dissect is used to solve problems.
+
+.. list-table:: References to articles on Dissect
+   :widths: 25 50 25
+   :header-rows: 1
+   :align: left
+
+   * - Publish Date
+     - Title
+     - Author
+   * - 2023-02-28
+     - `Scalable forensics timeline analysis using Dissect and Timesketch <https://www.huntandhackett.com/blog/scalable-forensics-timeline-analysis-using-dissect-and-timesketch>`_
+     - Zawadi Done / Hunt and Hackett
+   * - 2022-12-28
+     - `CVE-2022-27510, CVE-2022-27518 – Measuring Citrix ADC & Gateway version adoption on the Internet <https://blog.fox-it.com/2022/12/28/cve-2022-27510-cve-2022-27518-measuring-citrix-adc-gateway-version-adoption-on-the-internet/>`_
+     - Yun Zheng Hu / Fox-IT
+   * - 2022-12-26
+     - `Dissecting fortigate images for fun and non-profit <https://www.divd.nl/2022/12/26/dissecting-fortigate-images-for-fun-and-no-profit/>`_
+     - Axel Boesnach / DIVD
+   * - 2022-11-17
+     - `Parsing atop files with python dissect.cstruct <https://diablohorn.com/2022/11/17/parsing-atop-files-with-python-dissect-cstruct/>`_
+     - Francisco Dominguez
+   * - 2022-10-28
+     - `Dissecting Cobalt Strike using Python <https://github.com/fox-it/dissect.cobaltstrike>`_
+     - Yun Zheng Hu / Fox-IT
+  
+
+Tutorials
+---------
+
+The table below contains tutorials and starter guides written by community users.
+
+.. list-table:: References to tutorials and starter guides on Dissect
+   :widths: 25 50 25
+   :header-rows: 1
+   :align: left
+
+   * - Publish Date
+     - Title 
+     - Author
+   * - 2023-01-22
+     - `How to install and use Dissect (Forensic Framework) <https://muchipopo.com/forensic/dissect/?_x_tr_sl&_x_tr_tl&_x_tr_hl>`_
+     - Muchipopo
+   * - 2023-12-19 
+     - `The Dissect Effect - An Open Source IR Framework <https://www.youtube.com/watch?v=A2e203LizAM>`_
+     - 13Cubed  

--- a/docs/source/resources/dissect-in-action.rst
+++ b/docs/source/resources/dissect-in-action.rst
@@ -58,7 +58,7 @@ The table below contains tutorials and starter guides written by community users
      - Title 
      - Author
    * - 2023-01-22
-     - `How to install and use Dissect (Forensic Framework) <https://muchipopo.com/forensic/dissect/?_x_tr_sl&_x_tr_tl&_x_tr_hl>`_
+     - `How to install and use Dissect (Forensic Framework) <https://muchipopo.com/forensic/dissect/>`_
      - Muchipopo
    * - 2023-12-19 
      - `The Dissect Effect - An Open Source IR Framework <https://www.youtube.com/watch?v=A2e203LizAM>`_

--- a/docs/source/resources/dissect-in-action.rst
+++ b/docs/source/resources/dissect-in-action.rst
@@ -22,7 +22,7 @@ The table below contains references to articles where Dissect is used to solve p
 .. list-table:: References to articles on Dissect
    :widths: 25 50 25
    :header-rows: 1
-   :align: left
+   :class: left-text-align
 
    * - Publish Date
      - Title
@@ -52,7 +52,7 @@ The table below contains tutorials and starter guides written by community users
 .. list-table:: References to tutorials and starter guides on Dissect
    :widths: 25 50 25
    :header-rows: 1
-   :align: left
+   :class: left-text-align
 
    * - Publish Date
      - Title 

--- a/docs/source/resources/talks-and-conferences.rst
+++ b/docs/source/resources/talks-and-conferences.rst
@@ -1,0 +1,48 @@
+Talks and Conferences
+=====================
+
+On this page you will find references to talks and conferences where Dissect was presented.
+
+We regularly showcase different aspects of Dissect at conferences. Since each conference has a
+different audience and theme, we tailor our presentations to suit each of them.
+
+We encourage you to explore the links below and watch this page for any upcoming conferences.
+
+.. note::
+    Not all organizers release the presented material to the public after the conference. Links 
+    are supplied for reference purposes only.
+
+
+.. list-table:: Past and upcoming talks and conferences
+   :widths: 25 25 25 50
+   :header-rows: 1
+   :class: left-text-align
+
+   * - Date
+     - Conference
+     - Location
+     - Subject
+   * - 2023-06-05
+     - `FIRST <https://www.first.org/conference/2023/>`_
+     - Montreal (CA)
+     - Dissect: the solution to large-scale incident response (and why APTs hate us)
+   * - 2023-03-21
+     - `DFRWS <https://dfrws.org/conference/dfrws-eu-2023/>`_
+     - Bonn (DE)
+     - Cyber pathology with Dissect: DFRWS Workshop
+   * - 2023-01-16
+     - `SANS CyberThreat22 <https://www.ncsc.gov.uk/event/cyberthreat-2022>`_
+     - London (GB)
+     - Enterprise IR: live free, live large
+   * - 2022-12-07
+     - `FEF Europol <https://www.europol.europa.eu/publications-events/events/forensic-experts-forum-2022-conference>`_
+     - The Hague (NL)
+     - Dissect: The open-source framework for large-scale host investigations
+   * - 2022-10-27
+     - `dcypher Forensic Workshop <https://dcypher.nl/news/view/82aa787e-15f5-48fc-834d-2da3d8169f79/donderdag-donderdag-2-forensic-readiness-for-cybercrime>`_
+     - Leiden (NL)
+     - Introduction to Dissect
+   * - 2022-04-12
+     - `FIRST TC <https://www.first.org/events/colloquia/amsterdam2022/>`_
+     - Amsterdam (NL)
+     - I’m in Your Hypervisor, Collecting Your Evidence


### PR DESCRIPTION
Adds a section 'Resources' with two pages 'Dissect in Action' and 'Talks and Conferences'. The first links to external websites that blog about Dissect while the latter links to past and upcoming talks and conferences we give on Dissect.

In addition, it is now possible to (re)build the core documentation without having to (re)build the API references of all the submodules which safes a tremendous amount of building time when working on the documentation.