### PR TITLE
Rework 'Contributing' section

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,7 +46,8 @@ extensions = [
     "sphinx_argparse_cli",
     "sphinx_copybutton",
     "sphinx_design",
-    "autoapi.extension",
+    'sphinxcontrib.plantuml'
+#    "autoapi.extension",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,8 +46,7 @@ extensions = [
     "sphinx_argparse_cli",
     "sphinx_copybutton",
     "sphinx_design",
-    'sphinxcontrib.plantuml'
-#    "autoapi.extension",
+    "autoapi.extension",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/contributing/codestyle.py
+++ b/docs/source/contributing/codestyle.py
@@ -19,6 +19,9 @@ def function_with_an_exception() -> None:
 
     This function is only for illustratory purposes.
 
+    References:
+        - https://docs.dissect.tools/
+
     Raises:
         CodestyleException: Gets raised as an example
     """

--- a/docs/source/contributing/developing.rst
+++ b/docs/source/contributing/developing.rst
@@ -36,7 +36,7 @@ To build and test Dissect projects, `tox <https://tox.wiki/en/latest/>`_ is used
 Style guide
 ~~~~~~~~~~~
 
-Dissect has published a :doc:`style guide </contributing/style-guide>` for code, documentation and commit messages.
+Dissect has a :doc:`style guide </contributing/style-guide>` for code, documentation and commit messages.
 It helps to improve the quality of the code by making it more uniform in appearance which should increase the understandability and
 maintainability. It will also make the reviewing process easier and reduces the number of iterations to get the code in
 a mergeable shape.

--- a/docs/source/contributing/developing.rst
+++ b/docs/source/contributing/developing.rst
@@ -26,16 +26,7 @@ Development process
 Python and tox versions
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Dissect is built and tested for the following Python versions:
-
-- CPython 3.9, 3.10 and 3.11.
-- PyPy 3.9.
-
-Older versions than specified may not work, as some features are not supported by these versions
-(for example ``@cached_property`` is only supported since Python 3.9).
-
-
-Newer versions will probably work, but are not guaranteed to.
+.. include:: /versions.rst
 
 
 To build and test Dissect projects, `tox <https://tox.wiki/en/latest/>`_ is used.

--- a/docs/source/contributing/developing.rst
+++ b/docs/source/contributing/developing.rst
@@ -5,8 +5,27 @@ Developing for Dissect
 
     Thinking about writing your own Dissect module? Awesome! We kindly ask that you use the ``dissect.contrib.*`` namespace!
 
-Development
------------
+
+
+We very much welcome contributions from the community that improve Dissect. Before making your first contribution, we
+ask you to read our documentation on the development process, style guide and tooling carefully as they will help you make the contributing process as easy as possible.
+
+These pages are organized as follows:
+
+1. `Development process`_: information regarding the development process, including branching, review process and expectations on
+testing.
+
+2. :doc:`Style guide </contributing/style-guide>`: information on how to style code and documentation for a uniform style across all Dissect projects.
+
+3. :doc:`Tooling </contributing/tooling>`: information regarding the available tooling for building and testing code and documentation.
+
+
+Development process
+-------------------
+
+
+Python and tox versions
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Dissect is built and tested against Python 3.9 (CPython and PyPy). Older versions may not work, as features are used which
 may not yet be supported by these versions (for example ``@cached_property`` is only supported since Python 3.9).
@@ -14,78 +33,97 @@ Newer versions will probably work, but are not guaranteed to.
 
 To build and test Dissect projects, `tox <https://tox.wiki/en/latest/>`_ is used. A minimum version of 3.8 is required.
 
-When developing for Dissect, please make sure you follow :doc:`the style guide </contributing/style-guide>`. It helps to
-improve the quality of the code by making it more uniform in appearance which should increase the understandability and
+Style guide
+~~~~~~~~~~~
+
+Dissect has published a :doc:`style guide </contributing/style-guide>` for code, documentation and commit messages.
+It helps to improve the quality of the code by making it more uniform in appearance which should increase the understandability and
 maintainability. It will also make the reviewing process easier and reduces the number of iterations to get the code in
-a mergable shape.
+a mergeable shape.
 
-Branches & Tags
-~~~~~~~~~~~~~~~
+Branching
+~~~~~~~~~
 
-Development is done on so-called feature branches. When making changes, create a feature branch with a useful and short
+Each project has a ``main`` branch. The ``HEAD`` of this ``main`` branch is the potential release candidate for the project.
+
+Development is done on feature branches. When making changes, create a feature branch with a useful and short
 name like ``feature/some_new_awsome_feature`` or ``fix/some_bug_fix``. Using a namespace prefix like ``feature/`` or
 ``fix/`` keeps different types of changes clear.
 
-When you are done with building the feature or creating the fix, do a final run of the unit tests and linting and make a
-pull request. The code will be reviewed and tested again in our CI pipeline.
-
-Be aware that a feature branch should contain only a single, self-contained, feature or fix. On acceptance, the commits
+Feature branches should contain only a single, self-contained, feature or fix. On acceptance, the commits
 in the feature branch will be squashed into a single commit. If there are reasons to deviate from this, each *commit* on
 the feature branch should contain a single, self-contained, feature or fix. Also make sure to discuss up front if you
 think there is reason to deviate from the single feature/fix per feature branch.
 
-If the pull request is accepted, the commit will be merged into the ``main`` branch. The ``HEAD`` of this branch is the potential
-release candidate for the project. Once a release is done, it will be tagged with a version number.
+Submission and review process
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Building & testing
-------------------
+When you have finished work in your feature branch and the unit tests and linting tests pass, you can submit
+a pull request.
 
-The build uses PEP 517 and PEP 518. Together with ``tox``'s ``isolated_build`` feature this ensures there are no hidden
-dependencies on locally installed packages.
+Each pull request will be reviewed before including it in the official code base. Before manual review takes place,
+we will run our CI pipeline which executes unit tests and formatting checks. If your pull request does not pass these tests, manual
+review will not commence.
 
-The ``tox.ini`` configuration file together with the ``pyproject.toml`` and ``setup.py`` files will make sure the correct
-versions of all build, test and install dependencies (including the version of ``tox`` itself) are present or are
-installed during the build and test runs.
+If the pull request is accepted, the commit will be merged into the ``main`` branch.
+Your contribution will then be incorporated in the next release.
 
-Building
-~~~~~~~~
+Contributor License Agreement
+"""""""""""""""""""""""""""""
 
-To build source and wheel distributions of a project, run ``tox`` with the ``build`` testenv:
+We require all contributors to accept our Contributor License Ageement (CLA) before including contributions into our code base.
+The process of signing is very simple and is only required once:
 
-.. code-block:: console
+1. Submit your pull request
+2. If this is your first submission, a comment on your pull request will be posted by our DissectBot with the CLA text
+3. When you agree with the terms and conditions you reply with a GitHub comment as shown in the CLA text.
 
-    $ tox -e build
+Once the signing has been completed, the pull request will be processed.
 
-The source and wheel distributions are put in the ``dist/`` directory in the root of the project. Building is done using
-the default CPython 3 version on your system.
+Any future pull requests from the same account will be processed immediately.
 
-Testing
-~~~~~~~
+Dependencies
+~~~~~~~~~~~~
 
-The default ``tox`` run will lint and unit test the code:
+Dissect has a policy of 'least dependencies', meaning that the amount of dependencies on other Python packages should be as small
+as possible. This limits licensing issues and keeps the software supply chain manageable.
 
-.. code-block:: console
+Dissect already has a curated set of dependencies covering a lot of functionality. When adding new dependencies to Dissect, please
+add the reason for doing so in a commit message.
 
-    $ tox
+Dependencies should be added to ``pyproject.toml``.
 
-Linting is done using flake8 and unit tests (if applicable) are run against the default installed CPython 3 and PyPy 3.
-Make sure that the default Python version on your system is 3.9 if you want to run the unit tests using a supported
-Python version.
+Test cases
+~~~~~~~~~~
 
-To explicitly run the unit tests against a Python version use:
+New code and large refactors should have unit tests accompanying the changes even though not all existing code currently has unit tests.
+See :doc:`tooling </contributing/tooling>` for information on how execute test cases.
 
-.. code-block:: console
 
-    $ tox -e py310
+Documentation
+~~~~~~~~~~~~~
 
-Or in case of using PyPy:
+Each project generates its own API reference documentation from the docstrings in the code using ``sphinx-autoapi``.
+All this documentation will be included under the 'API Reference' header on https://docs.dissect.tools.
 
-.. code-block:: console
+The :doc:`style guide </contributing/style-guide>` explains how to format the docstrings for a uniform styling across
+all the different projects.
 
-    $ tox -e pypy310
+There is also tooling to preview and check the auto-generated API documentation before submitting your code which
+is described in :doc:`tooling </contributing/tooling>`.
 
-To run just the linting:
+Releases and versioning
+~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: console
+Releases are done by the Dissect core team. Each release has a unique version number.
 
-    $ tox -e lint
+New releases are made from the ``main`` branch. Once a release is done, that version of the code is tagged with a version number.
+Version numbers are of the form ``x.y``, where
+
+- ``x`` is an epoch number
+- ``y`` is an iteration number.
+
+There are no compatibility
+guarantees between the different Python packages with the same ``x`` version. Only a fixed set of packages at the time of
+release should be expected to work well together. This set of packages is published in a release of the ``dissect`` Python
+package through the requirements in its ``pyproject.toml`` file.

--- a/docs/source/contributing/developing.rst
+++ b/docs/source/contributing/developing.rst
@@ -85,7 +85,7 @@ Any future pull requests from the same account will be processed immediately.
 Dependencies
 ~~~~~~~~~~~~
 
-Dissect has a policy of 'least dependencies', meaning that the amount of dependencies on other Python packages should be as small
+Dissect has a policy of 'least dependencies', meaning that the number of dependencies on other Python packages should be as small
 as possible. This limits licensing issues and keeps the software supply chain manageable.
 
 Dissect already has a curated set of dependencies covering a lot of functionality. When adding new dependencies to Dissect, please
@@ -97,7 +97,7 @@ Test cases
 ~~~~~~~~~~
 
 New code and large refactors should have unit tests accompanying the changes even though not all existing code currently has unit tests.
-See :doc:`tooling </contributing/tooling>` for information on how execute test cases.
+See :doc:`tooling </contributing/tooling>` for information on how to execute test cases.
 
 
 Documentation

--- a/docs/source/contributing/developing.rst
+++ b/docs/source/contributing/developing.rst
@@ -47,7 +47,7 @@ Branching
 Each project has a ``main`` branch. The ``HEAD`` of this ``main`` branch is the potential release candidate for the project.
 
 Development is done on feature branches. When making changes, create a feature branch with a useful and short
-name like ``feature/some_new_awsome_feature`` or ``fix/some_bug_fix``. Using a namespace prefix like ``feature/`` or
+name like ``feature/some_new_awesome_feature`` or ``fix/some_bug_fix``. Using a namespace prefix like ``feature/`` or
 ``fix/`` keeps different types of changes clear.
 
 Feature branches should contain only a single, self-contained, feature or fix. On acceptance, the commits
@@ -72,13 +72,13 @@ Contributor License Agreement
 """""""""""""""""""""""""""""
 
 We require all contributors to accept our Contributor License Ageement (CLA) before including contributions into our code base.
-The process of signing is very simple and is only required once:
+The process of accepting the agreement is very simple and is only required once:
 
 1. Submit your pull request
 2. If this is your first submission, a comment on your pull request will be posted by our DissectBot with the CLA text
 3. When you agree with the terms and conditions you reply with a GitHub comment as shown in the CLA text.
 
-Once the signing has been completed, the pull request will be processed.
+Once you have accepted the CLA, the pull request will be processed.
 
 Any future pull requests from the same account will be processed immediately.
 

--- a/docs/source/contributing/developing.rst
+++ b/docs/source/contributing/developing.rst
@@ -8,7 +8,7 @@ Developing for Dissect
 Development
 -----------
 
-Dissect is build and tested against Python 3.9 (CPython and PyPy). Older versions may not work, as features are used which
+Dissect is built and tested against Python 3.9 (CPython and PyPy). Older versions may not work, as features are used which
 may not yet be supported by these versions (for example ``@cached_property`` is only supported since Python 3.9).
 Newer versions will probably work, but are not guaranteed to.
 
@@ -24,17 +24,17 @@ Branches & Tags
 
 Development is done on so-called feature branches. When making changes, create a feature branch with a useful and short
 name like ``feature/some_new_awsome_feature`` or ``fix/some_bug_fix``. Using a namespace prefix like ``feature/`` or
-``fix/`` may help keep different types of changes clear.
+``fix/`` keeps different types of changes clear.
 
 When you are done with building the feature or creating the fix, do a final run of the unit tests and linting and make a
 pull request. The code will be reviewed and tested again in our CI pipeline.
 
-Be aware that a feature branch should contain only a single, self contained feature or fix. On acceptance, the commits
+Be aware that a feature branch should contain only a single, self-contained, feature or fix. On acceptance, the commits
 in the feature branch will be squashed into a single commit. If there are reasons to deviate from this, each *commit* on
-the feature branch should contain a single, self contained feature or fix. Also make sure to discuss up front if you
+the feature branch should contain a single, self-contained, feature or fix. Also make sure to discuss up front if you
 think there is reason to deviate from the single feature/fix per feature branch.
 
-If the pull request is accepted, the commit will land in the ``main`` branch. The ``HEAD`` of this branch is the potential
+If the pull request is accepted, the commit will be merged into the ``main`` branch. The ``HEAD`` of this branch is the potential
 release candidate for the project. Once a release is done, it will be tagged with a version number.
 
 Building & testing

--- a/docs/source/contributing/developing.rst
+++ b/docs/source/contributing/developing.rst
@@ -12,12 +12,11 @@ ask you to read our documentation on the development process, style guide and to
 
 These pages are organized as follows:
 
-1. `Development process`_: information regarding the development process, including branching, review process and expectations on
-testing.
+- `Development process`_: information regarding the development process, including branching, review process and expectations on testing.
 
-2. :doc:`Style guide </contributing/style-guide>`: information on how to style code and documentation for a uniform style across all Dissect projects.
+- :doc:`Style guide </contributing/style-guide>`: information on how to style code and documentation for a uniform style across all Dissect projects.
 
-3. :doc:`Tooling </contributing/tooling>`: information regarding the available tooling for building and testing code and documentation.
+- :doc:`Tooling </contributing/tooling>`: information regarding the available tooling for building and testing code and documentation.
 
 
 Development process
@@ -27,11 +26,24 @@ Development process
 Python and tox versions
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Dissect is built and tested against Python 3.9 (CPython and PyPy). Older versions may not work, as features are used which
-may not yet be supported by these versions (for example ``@cached_property`` is only supported since Python 3.9).
+Dissect is built and tested for the following Python versions:
+
+- CPython 3.9, 3.10 and 3.11.
+- PyPy 3.9.
+
+Older versions than specified may not work, as some features are not supported by these versions
+(for example ``@cached_property`` is only supported since Python 3.9).
+
+
 Newer versions will probably work, but are not guaranteed to.
 
-To build and test Dissect projects, `tox <https://tox.wiki/en/latest/>`_ is used. A minimum version of 3.8 is required.
+
+To build and test Dissect projects, `tox <https://tox.wiki/en/latest/>`_ is used.
+A minimum version of 4.2.4 is required (when using ``tox`` version 3.3.0 or higher,
+it will automatically bootstrap to this minimum version).
+
+More information on available tooling can be found on the :doc:`tooling </contributing/tooling>` page.
+
 
 Style guide
 ~~~~~~~~~~~

--- a/docs/source/contributing/style-guide.rst
+++ b/docs/source/contributing/style-guide.rst
@@ -1,25 +1,28 @@
 Style guide
 ===========
 
-This is a basic style guide for the dissect projects. The goal of this guide is to help improve the quality of the code
+This is a basic style guide for the Dissect projects. The goal of this guide is to help improve the quality of the code
 by making it more uniform in appearance which should increase the understandability and maintainability. When submitting
-code for inclusion in one of the dissect projects, it helps to follow this guide. This will make the reviewing process
+code for inclusion in one of the Dissect projects, it helps to follow this guide. This will make the reviewing process
 easier and reduces the number of iterations to get it the code in a mergable shape.
 
-Although certain things are enforced in the build pipeline, the current code does not adhere everywhere and always to
-all these guidelines. The reason is that it already has quite some history. Nonetheless, by following these guidelines
-we improve the code as we go.
+Although certain style checks are enforced in the build pipeline, the current code does not always adhere to
+all these guidelines. The reason for the latter is that Dissect contains code that was written a long time before this guide
+was developed. Changing existing code to match this style guide is a continuous process, but new code should definitely
+follow this guide.
 
 A note on refactoring
 ---------------------
 
 For the parts of these guidelines which are not enforced by our build pipeline we generally deal with them in the
 following way. As a rule, new code should always strive to follow these guidelines. For code that gets modified and
-is not yet fully following these guidelines, there are the following options. If the change is large, it is best to
-refactor the function, method or class according to these guidelines. If the change is minor, or if it wouldn't fit
-in the context of the rest of the code in the class, file or sub-project, refactoring for things like type hinting
-and adding docstrings may be postponed until a larger change or refactor. Paramount however is that the change you
-make is understandable and clear in its functioning.
+is not yet fully following these guidelines, there are the following options:
+
+- If the change is large, it is best to refactor the function, method or class according to these guidelines.
+- If the change is minor, or if it wouldn't fit in the context of the rest of the code in the class, file or sub-project, refactoring for things like type hinting
+and adding docstrings may be postponed until a larger change or refactor.
+
+Paramount however is that the change you make is understandable and clear in its functioning.
 
 PEP 8 and Black
 ---------------
@@ -43,7 +46,7 @@ Import order
 ------------
 
 When importing other modules or files we group the imports into 3 groups. First are the builtin modules, next the modules
-from external projects *including* other dissect projects, e.g. PyYAML, and finally the modules from the project itself.
+from external projects *including* other Dissect projects, e.g. PyYAML, and finally the modules from the project itself.
 The imports within the 3 groups should be in alphabetical order, as in the example below:
 
 .. code-block:: python

--- a/docs/source/contributing/style-guide.rst
+++ b/docs/source/contributing/style-guide.rst
@@ -1,53 +1,79 @@
 Style guide
 ===========
 
-This is a basic style guide for the Dissect projects. The goal of this guide is to help improve the quality of the code
-by making it more uniform in appearance which should increase the understandability and maintainability. When submitting
-code for inclusion in one of the Dissect projects, it helps to follow this guide. This will make the reviewing process
-easier and reduces the number of iterations to get it the code in a mergable shape.
+This is a basic style guide for the Dissect projects. The goal of this guide is to increase the understandability and maintainability
+of both code and documentation.
 
-Although certain style checks are enforced in the build pipeline, the current code does not always adhere to
-all these guidelines. The reason for the latter is that Dissect contains code that was written a long time before this guide
-was developed. Changing existing code to match this style guide is a continuous process, but new code should definitely
-follow this guide.
+Applicability
+-------------
 
-A note on refactoring
----------------------
+This guide is applicable to both new and exisiting code and the Dissect build pipeline enforces the most important rules.
+Certain exceptions are made for older parts of the code as they were written before the creation of this guide.
 
-For the parts of these guidelines which are not enforced by our build pipeline we generally deal with them in the
-following way. As a rule, new code should always strive to follow these guidelines. For code that gets modified and
-is not yet fully following these guidelines, there are the following options:
+New code
+^^^^^^^^
 
-- If the change is large, it is best to refactor the function, method or class according to these guidelines.
-- If the change is minor, or if it wouldn't fit in the context of the rest of the code in the class, file or sub-project, refactoring for things like type hinting
-and adding docstrings may be postponed until a larger change or refactor.
+When submitting new code for inclusion in one of the Dissect projects, your code should adhere
+to this guide unless there is a valid reason not to do so. This motivation should be added to your eventual
+Pull Request.
 
-Paramount however is that the change you make is understandable and clear in its functioning.
+Older code
+^^^^^^^^^^
+
+When submitting changes to existing code that does not yet adhere to this style guide, a choice should be made
+whether or not to make the change conformant to the guidelines. You can use the rules below to help you decide
+what to do in these cases.
+
+If the change in existing code is
+
+- large, it is best to refactor the function, method or class according to these guidelines.
+- small and rewriting the code for guideline conformance would not be proportional to the change itself, you may submit the code using the original styling.
+
+.. note::
+    Regardless of conformance to this style guide, any change you make should be understandable and clear in its functioning.
+
+
+Code style and formatting
+-------------------------
+
+This section lists how to format code in a readable and consistent manner and which specifications and tools are used to
+enforce them.
 
 PEP 8 and Black
----------------
+^^^^^^^^^^^^^^^
 
 The code should adhere to the `PEP 8 <https://peps.python.org/pep-0008/>`_ Python code style. The adherence to PEP 8
-is checked using `Flake8 <https://flake8.pycqa.org/>`_. As PEP 8 is not completely unambiguous and Flake8 also makes
-certain choices as to how to interpret it, we decided to ignore all flake ``E203`` errors
-(see `<https://github.com/PyCQA/pycodestyle/issues/373>`_).
+is checked using `Flake8 <https://flake8.pycqa.org/>`_. Flake ``E203`` errors can be ignored due to the ambigious nature
+of these errors (see `<https://github.com/PyCQA/pycodestyle/issues/373>`_).
 
-We also set the line limit at 120 characters. For modern console sizes this gives a bit more room compared to the
-standard 80 character limit without sacrificing readability, probably even increasing it.
-
-The formatting of the code layout is further refined by using `Black <https://black.readthedocs.io/en/stable/>`_. This is
-done for a number of reasons: to have a way to automatically format the code, to have it be consistent between files and
-projects regardless of the author and, most importantly, to not have to spend energy on thinking what the exact formatting
-should be.
+The formatting of the code layout is further refined by using `Black <https://black.readthedocs.io/en/stable/>`_.
+Black provides functionality to automatically format code and enforces consistent coding style between files and projects regardless
+of the author. It also relieves authors of the burden of having to actively think about the formatting.
 
 PEP 8 and Black styles are mandatory. This is configured in the project's ``tox.ini`` files and tested for by our build pipeline.
 
-Import order
-------------
+Maximum line length
+^^^^^^^^^^^^^^^^^^^
 
-When importing other modules or files we group the imports into 3 groups. First are the builtin modules, next the modules
-from external projects *including* other Dissect projects, e.g. PyYAML, and finally the modules from the project itself.
-The imports within the 3 groups should be in alphabetical order, as in the example below:
+Lines should be limited to 120 characters. For modern console sizes this gives a bit more room compared to the
+standard 80 character limit without sacrificing readability, probably even increasing it.
+
+Type hinting
+^^^^^^^^^^^^
+
+New functions and classes should be fully type hinted. The combination of type hinting and docstrings helps in understanding
+what the function or class does and how it should be used.
+
+Import order
+^^^^^^^^^^^^
+
+Import statements for files and modules are divided into three groups and should be ordered as indicated below:
+
+1. builtin modules
+2. modules from external projects *including* other Dissect projects, e.g. PyYAML
+3. modules from the project itself.
+
+The imports within each group should be in alphabetical order, as in the example below:
 
 .. code-block:: python
 
@@ -63,50 +89,11 @@ The imports within the 3 groups should be in alphabetical order, as in the examp
     import this_dissect_project
     from this_dissect_project import bla
 
+Formatting tuples
+^^^^^^^^^^^^^^^^^
 
-Type hinting
-------------
-
-New functions and classes should be fully type hinted. The combination of type hinting and docstrings helps in understanding
-what the function or class does and how it should be used.
-
-Docstring style
----------------
-
-Functions and classes should have docstrings detailing what that function or class does and/or how it should be used. We
-follow the `Google docstring format <https://google.github.io/styleguide/pyguide.html#s3.8-comments-and-docstrings>`_ and
-use the ``sphinx-apidoc`` tool to automatically generate the API documentation.
-
-The first line of a docstring should contain a short sentence describing the nature of the function/class, followed by an
-empty line and optionally a more verbose explanation detailing how the function/class goes about doing its thing and/or how
-it should be used. Finally, add an indented list of arguments, return value(s) and exceptions which can be raised according
-to the Google docstring format. Typing of these parameters should be done through type hinting.
-
-An example of how to use the docstring to comment a function/method.
-
-.. literalinclude:: codestyle.py
-
-The examples above look like this:
-
-.. automodule:: codestyle
-    :members:
-
-The most important takeaways are:
-
-* Use ``typehints`` so type information gets automatically added to the documentation
-* ``Args:`` To document parameters
-* ``Returns:`` To document what it specifically returns
-* ``Raises:`` To document if it raises a specific exception and why
-
-Misc styling recommendations
-----------------------------
-
-Tuples and Black
-~~~~~~~~~~~~~~~~
-
-As Black tries to cram as much content on a single line as possible, it may sometimes interfere with aesthetics. One instance
-is when you want a tuple of items formatted over multiple lines. To prevent them from being put on a single line by Black is
-to add a comma (``,``) after the last item of the tuple, like this:
+Care should be taken when formatting tuples as Black attempts to reformat all elements into a single line.
+To prevent this, add a comma (``,``) after the last item of the tuple, like this:
 
 .. code-block:: python
 
@@ -118,15 +105,22 @@ to add a comma (``,``) after the last item of the tuple, like this:
 Coincidentally, this also gives cleaner code diffs when adding or removing items from the tuple later on.
 
 Naming variables
-~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^
 
-Naming variables is always a hard problem. A short list to think of when naming variables:
+Naming variables can be challenging. When deciding on a variable name, take the following rules into account:
 
-* Single-character variable names are frowned upon.
-* Variables which are named after their type (list, dict etc.) are generally not a good choice.
+* Avoid single-character variable names.
+* Don't name variables after their type (list, dict etc.).
 
-dissect.cstruct definitions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Incorporating dissect.cstruct definitions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Writing structure definitions is an essential part of writing a new parser. The following rules show how to
+format them properly.
+
+Split definition and loading
+""""""""""""""""""""""""""""
 
 When using ``dissect.cstruct`` to define and load C structures, split the definition of the structure and the loading of the
 structure:
@@ -142,14 +136,18 @@ structure:
 This increases readability and allows you to add a ``# noqa: E501`` after the string defining the C structure. This is useful
 if the definition comes from an external source which has lines that are too long, but you want to keep the original layout.
 
-When writing structure definitions for a new parser, try to keep the structure style similar to the original structures, if
-possible.
+Styling structure definitions
+"""""""""""""""""""""""""""""
 
-If open-source or openly documented structures are available, use them as much as possible. Changing field types or slightly
+The main rule for styling structure definitions is to keep the style similar to the original structures when this is possible.
+
+Below follows more specific rules depending on the availability of the structures:
+
+1. If open-source or openly documented structures are available, use them as much as possible. Changing field types or slightly
 altering structures for performance or compatibility reasons is encouraged. For example, ``char[n]`` is faster than ``int8[n]``,
 or changing a ``GUID field_name`` to ``char field_name[16]``.
 
-If no original structures are available, make an educated guess on what they could look like in the original source.
+2. If no original structures are available, make an educated guess on what they could look like in the original source.
 For example, during reverse engineering you see a debug log message that uses ``lowerCamelCase`` field names, use that
 style for your field names.
 
@@ -157,24 +155,53 @@ If no discernible style is visible, you can use the following general rules:
 
 * For a Microsoft file format, use ``UPPERCASE_NAME`` structure names and ``CamelCase`` field names.
 
-  * One exception is that we generally remove field prefixes like ``dw`` and ``cb``, even when copy-pasting structures.
+  * One exception is that field prefixes like ``dw`` and ``cb`` should be removed, even when copy-pasting structures.
 
 * For other file formats, use ``lowercase_name`` structure and field names.
 
-Not every parser in ``dissect`` currently adheres to this style, but we try to adhere to these rules for future parsers.
+Documentation style and formatting
+----------------------------------
 
-Test cases
-----------
+New code needs to be documented properly using docstrings. To understand how documentation
+is organised and generated, check out the :doc:`developing for Dissect </contributing/developing>` page.
 
-We try to unit test as much of the code as possible. As this project originally evolved without a lot of test cases, it is
-a sort of catch-up game. New code and large refactors should have unit tests accompanying the changes.
+Use of docstrings
+^^^^^^^^^^^^^^^^^
 
-Commit style, tags and branches
--------------------------------
+Functions and classes should have docstrings detailing what that function or class does and/or how it should be used. They
+should be formatted as described in the `Google docstring format <https://google.github.io/styleguide/pyguide.html#s3.8-comments-and-docstrings>`_.
 
-All development should be done on so-called feature branches. Each branch must contain only a single feature or change.
-These branches are rebased and squashed on top of the ``main`` branch. The idea is to have the ``main`` branch always in
-a (more or less) releasable state.
+The first line of a docstring should contain a short sentence describing the nature of the function/class, followed by an
+empty line and optionally a more verbose explanation detailing how the function/class goes about doing its thing and/or how
+it should be used. Finally, add an indented list of arguments, return value(s) and exceptions which can be raised according
+to the Google docstring format.
+
+Typing of parameters should be done through type hinting.
+
+Use the ``References:`` clause when referencing external resources such as URLs to websites.
+
+Example docstrings
+^^^^^^^^^^^^^^^^^^
+
+An example of how to use the docstring to comment a function/method:
+
+.. literalinclude:: codestyle.py
+
+The examples above look like this:
+
+.. automodule:: codestyle
+    :members:
+
+The most important takeaways are:
+
+* Use ``typehints`` so type information gets automatically added to the documentation
+* ``Args:`` To document parameters
+* ``Returns:`` To document what it specifically returns
+* ``Raises:`` To document if it raises a specific exception and why
+
+
+Commit message style and formatting
+-----------------------------------
 
 Commit messages should adhere to the following points:
 
@@ -187,7 +214,10 @@ Commit messages should adhere to the following points:
 * Wrap the body at 72 characters
 * Use the body to explain the what and why vs. the how
 
-An example of a commit message:
+Example commit message
+^^^^^^^^^^^^^^^^^^^^^^
+
+An example of a properly formatted commit message:
 
 .. code-block:: text
 
@@ -196,9 +226,3 @@ An example of a commit message:
     Sometimes extra null bytes can be present at the end of the NTFS allocator
     table, this patch makes sure they are not included in the next header
     structure.
-
-When the ``main`` branch gets released, it is tagged with a version in the form of ``x.y``. This version is not strictly
-a semantic version number. The ``x`` is more like an epoch and the ``y`` an iteration number. There are no compatibility
-guarantees between the different Python packages with the same ``x`` version. Only the set of packages at the time of
-release should be expected to work well together. This set of packages is codified in a release of the ``dissect`` Python
-package through the requirements in its ``setup.py``.

--- a/docs/source/contributing/style-guide.rst
+++ b/docs/source/contributing/style-guide.rst
@@ -7,7 +7,7 @@ of both code and documentation.
 Applicability
 -------------
 
-This guide is applicable to both new and exisiting code and the Dissect build pipeline enforces the most important rules.
+This guide is applicable to both new and existing code and the Dissect build pipeline enforces the most important rules.
 Certain exceptions are made for older parts of the code as they were written before the creation of this guide.
 
 New code
@@ -21,7 +21,7 @@ Older code
 ^^^^^^^^^^
 
 When submitting changes to existing code that does not yet adhere to this style guide, a choice should be made
-whether or not to make the change conformant to the guidelines. You can use the rules below to help you decide
+whether to make the change conformant to the guidelines. You can use the rules below to help you decide
 what to do in these cases.
 
 If the change in existing code is
@@ -43,7 +43,7 @@ PEP 8 and Black
 ^^^^^^^^^^^^^^^
 
 The code should adhere to the `PEP 8 <https://peps.python.org/pep-0008/>`_ Python code style. The adherence to PEP 8
-is checked using `Flake8 <https://flake8.pycqa.org/>`_. Flake ``E203`` errors can be ignored due to the ambigious nature
+is checked using `Flake8 <https://flake8.pycqa.org/>`_. Flake ``E203`` errors can be ignored due to the ambiguous nature
 of these errors (see `<https://github.com/PyCQA/pycodestyle/issues/373>`_).
 
 The formatting of the code layout is further refined by using `Black <https://black.readthedocs.io/en/stable/>`_.
@@ -56,7 +56,7 @@ Maximum line length
 ^^^^^^^^^^^^^^^^^^^
 
 Lines should be limited to 120 characters. For modern console sizes this gives a bit more room compared to the
-standard 80 character limit without sacrificing readability, probably even increasing it.
+standard 80-character limit without sacrificing readability, probably even increasing it.
 
 Type hinting
 ^^^^^^^^^^^^
@@ -102,7 +102,7 @@ To prevent this, add a comma (``,``) after the last item of the tuple, like this
         param2,
     )
 
-Coincidentally, this also gives cleaner code diffs when adding or removing items from the tuple later on.
+Coincidentally, this also gives cleaner code diffs when adding or removing items from the tuple later.
 
 Naming variables
 ^^^^^^^^^^^^^^^^

--- a/docs/source/contributing/tooling.rst
+++ b/docs/source/contributing/tooling.rst
@@ -7,6 +7,8 @@ Build system
 ~~~~~~~~~~~~
 
 Each project includes tooling for building and testing code and documentation.
+The :doc:`developing for Dissect page </contributing/developing>` lists the supported Python
+and ``tox`` versions.
 
 The build system adheres to `PEP 517 <https://peps.python.org/pep-0517/>`_, `PEP 518 <https://peps.python.org/pep-0518/>`_
 and `PEP 626 <https://peps.python.org/pep-0626>`_.

--- a/docs/source/contributing/tooling.rst
+++ b/docs/source/contributing/tooling.rst
@@ -1,6 +1,11 @@
 Tooling
 =======
 
+This page covers the available tooling to help you build and test both code and documentation.
+
+Build system
+~~~~~~~~~~~~
+
 Each project includes tooling for building and testing code and documentation.
 
 The build system adheres to `PEP 517 <https://peps.python.org/pep-0517/>`_, `PEP 518 <https://peps.python.org/pep-0518/>`_

--- a/docs/source/contributing/tooling.rst
+++ b/docs/source/contributing/tooling.rst
@@ -44,6 +44,12 @@ Linting is done using flake8 and unit tests (if applicable) are run against the 
 Make sure that the default Python version on your system is 3.9 if you want to run the unit tests using a supported
 Python version.
 
+.. important::
+
+    Some repositories require ``git lfs`` (Large File Storage) to retrieve testdata needed for testing. If you had this installed prior
+    to cloning the repository, no further action is required to complete the tests. Otherwise, install ``git lfs`` and type
+    ``git lfs pull`` in the repository to download the testdata.
+
 To explicitly run the unit tests against a Python version use:
 
 .. code-block:: console

--- a/docs/source/contributing/tooling.rst
+++ b/docs/source/contributing/tooling.rst
@@ -81,7 +81,7 @@ You can generate the API documentation in HTML format using ``tox`` for viewing 
 
 .. code-block:: console
 
-    $ tox -e docsbuild
+    $ tox -e docs-build
 
 This will create the ``tests/docs/build/html`` directory with the generated documentation in HTML format.
 Apart from the styling, this will show you how your documentation will appear
@@ -108,7 +108,7 @@ You can check for broken links by invoking the following command:
 
 .. code-block:: console
 
-    $ tox -e docslinkcheck
+    $ tox -e docs-linkcheck
 
 
 You will see the results of the checks in your terminal, but they can also be found in the file

--- a/docs/source/contributing/tooling.rst
+++ b/docs/source/contributing/tooling.rst
@@ -61,8 +61,8 @@ If linting fails, you can try to automatically fix the linting using the followi
 .. code-block:: console
 
     $ tox -e fix
-    
-.. warning::     
+
+.. warning::
     Always check the results of ``tox -e fix`` before submitting as the proposed changes may not always be the most optimal solution.
 
 Testing documentation
@@ -70,7 +70,7 @@ Testing documentation
 
 There is tooling to:
 
-- generate the API documentation for manual inspection in a web browser 
+- generate the API documentation for manual inspection in a web browser
 - automatically check for broken URLs in the documentation.
 
 
@@ -83,25 +83,25 @@ You can generate the API documentation in HTML format using ``tox`` for viewing 
 
     $ tox -e docsbuild
 
-This will create the `tests/docs/build/html` directory with the generated documentation in HTML format.
-Apart from the styling, this will show you how your documentation will appear 
+This will create the ``tests/docs/build/html`` directory with the generated documentation in HTML format.
+Apart from the styling, this will show you how your documentation will appear
 on https://docs.dissect.tools if your changes are accepted.
 
 
-**Note**: It is not unusual that warnings and errors appear; you can safely ignore them as long as
-the building of the documentation does not fail in its entirety.
+.. note::
+    It is not unusual that warnings and errors appear while building; you can safely ignore them as long as the building of the documentation does not fail in its entirety.
 
 After the build process has finished, you can view the documentation in, for example, Firefox:
 
 .. code-block:: console
-     
+
      $ firefox tests/docs/build/html/index.html
 
 
 Checking external URLs
 ^^^^^^^^^^^^^^^^^^^^^^
 
-If you include external website URLs in your API documentation, it is good to validate if these 
+If you include external website URLs in your API documentation, it is good to validate if these
 links are still valid before commiting your changes.
 
 You can check for broken links by invoking the following command:
@@ -111,16 +111,20 @@ You can check for broken links by invoking the following command:
     $ tox -e docslinkcheck
 
 
-You will see the results of the checks in your terminal, but they can also be found in the file 
+You will see the results of the checks in your terminal, but they can also be found in the file
 ``tests/docs/build/linkcheck/output.txt``.
 
+The following section helps you understand the results of the command.
+
 Understanding linkcheck output
-""""""""""""""""""""""""""""""  
+""""""""""""""""""""""""""""""
 
-Each URL that is checked will result in a line containing the file and linenumber containing the URL, 
-the result of the check (see below) and the actual URL that was checked.
+Each line in ``tests/docs/build/linkcheck/output.txt`` corresponds to one URL that has been checked and shows:
+- the filename and line number where the URL is mentioned
+- the result of the check
+- the actual URL that was checked.
 
-Use the following table to process the output:
+Use the following table to interpret the result of the check:
 
 .. list-table:: How to process linkcheck results
    :widths: 20 40 40
@@ -136,8 +140,13 @@ Use the following table to process the output:
      - The URL resolves after following a redirect
      - No change required
    * - broken
-     - The URL doesn't appear to be working
-     - Determine the cause of failure: check in the HTML if the URL is rendered properly. Does the website block the check but does the URL function when using a browser? In the latter case, the link can be kept, otherwise consider removing the link.
+     - The URL doesn't appear to be working.
+     -
+        - If the refererenced page has been moved, replace the URL with its new location
+        - If the refererenced page is no longer available, consider creating an `archive.org <https://archive.org>`_ URL
+        - Check in the HTML if the URL is rendered properly
+        - URLs containing ``(`` and ``)`` should have these characters escaped as ``%28`` and ``%29`` respectively
+        - Check if the URL works when clicking from the generated HTML. If it works the link can be kept, otherwise consider removing the link.
    * - *other*
      - An unforeseen error occured
      - Manually check if the link is still valid; remove the link if necessary.

--- a/docs/source/contributing/tooling.rst
+++ b/docs/source/contributing/tooling.rst
@@ -1,0 +1,153 @@
+Tooling
+=======
+
+Each project includes tooling for building and testing code and documentation.
+
+The build system adheres to `PEP 517 <https://peps.python.org/pep-0517/>`_, `PEP 518 <https://peps.python.org/pep-0518/>`_
+and `PEP 626 <https://peps.python.org/pep-0626>`_.
+Together with ``tox``'s ``isolated_build`` feature this ensures that there are no hidden
+dependencies on locally installed packages.
+
+The ``tox.ini`` and ``pyproject.toml`` files will make sure the correct
+versions of all build, test and install dependencies (including the version of ``tox`` itself) are present or are
+installed during the build and test runs.
+
+Building
+~~~~~~~~
+
+To build source and wheel distributions of a project, run ``tox`` with the ``build`` testenv:
+
+.. code-block:: console
+
+    $ tox -e build
+
+The source and wheel distributions are put in the ``dist/`` directory in the root of the project. Building is done using
+the default CPython 3 version on your system.
+
+Testing
+~~~~~~~
+
+The default ``tox`` run will lint and unit test the code:
+
+.. code-block:: console
+
+    $ tox
+
+Linting is done using flake8 and unit tests (if applicable) are run against the default installed CPython 3 and PyPy 3.
+Make sure that the default Python version on your system is 3.9 if you want to run the unit tests using a supported
+Python version.
+
+To explicitly run the unit tests against a Python version use:
+
+.. code-block:: console
+
+    $ tox -e py310
+
+Or in case of using PyPy:
+
+.. code-block:: console
+
+    $ tox -e pypy310
+
+To run just the linting:
+
+.. code-block:: console
+
+    $ tox -e lint
+
+
+If linting fails, you can try to automatically fix the linting using the following command:
+
+.. code-block:: console
+
+    $ tox -e fix
+    
+.. warning::     
+    Always check the results of ``tox -e fix`` before submitting as it is possible that the suggested changes may alter the code in 
+    an unintended way.
+
+Testing documentation
+~~~~~~~~~~~~~~~~~~~~~
+
+There is tooling to:
+
+- generate the API documentation for manual inspection in a web browser 
+- automatically check for broken URLs in the documentation.
+
+
+Previewing documentation
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can generate the API documentation in HTML format using ``tox`` for viewing in a web browser as follows:
+
+.. code-block:: console
+
+    $ tox -e FIXME
+
+This will create the `FIXME build` directory with the generated documentation in HTML format.
+Apart from the styling, this will show you how your documentation will appear 
+on https://docs.dissect.tools if your changes are accepted.
+
+
+**Note**: It is not unusual that warnings and errors appear; you can safely ignore them as long as
+the building of the documentation does not fail in its entirety.
+
+After the build process has finished, you can view the documentation in, for example, Firefox:
+
+.. code-block:: console
+     
+     $ firefox build/html/index.html
+
+
+If you experience build issues, you can clean up your environment using:
+
+.. code-block:: console
+    
+    $ make clean FIXME
+
+
+Checking external URLs
+^^^^^^^^^^^^^^^^^^^^^^
+
+If you include external website URLs in your API documentation, it is good to validate if these 
+links are still valid before commiting your changes.
+
+You can check for broken links by invoking the following command:
+
+.. code-block:: console
+
+    $ tox -e FIXME linkcheck
+
+
+You will see the results of the checks in your terminal, but they can also be found in the file 
+`FIXME build/linkcheck/output.txt`.
+
+Understanding linkcheck output
+""""""""""""""""""""""""""""""  
+
+Each URL that is checked will result in a line containing the file and linenumber containing the URL, 
+the result of the check (see below) and the actual URL that was checked.
+
+Use the following table to process the output:
+
+.. list-table:: How to process linkcheck results
+   :widths: 20 40 40
+   :header-rows: 1
+
+   * - Result Code
+     - Meaning
+     - Resolve
+   * - ok
+     - The URL resolves without issues
+     - No change required
+   * - redirect
+     - The URL resolves after following a redirect
+     - No change required
+   * - broken
+     - The URL doesn't appear to be working
+     - Determine the cause of failure: check in the HTML if the URL is rendered properly. Does the website block the check but does the URL function when using a browser? In the latter case, the link can be kept, otherwise consider removing the link.
+   * - *other*
+     - An unforeseen error occured
+     - Manually check if the link is still valid; remove the link if necessary.
+
+

--- a/docs/source/contributing/tooling.rst
+++ b/docs/source/contributing/tooling.rst
@@ -83,7 +83,7 @@ You can generate the API documentation in HTML format using ``tox`` for viewing 
 
     $ tox -e docsbuild
 
-This will create the `tests/docs./build/html` directory with the generated documentation in HTML format.
+This will create the `tests/docs/build/html` directory with the generated documentation in HTML format.
 Apart from the styling, this will show you how your documentation will appear 
 on https://docs.dissect.tools if your changes are accepted.
 

--- a/docs/source/contributing/tooling.rst
+++ b/docs/source/contributing/tooling.rst
@@ -63,8 +63,7 @@ If linting fails, you can try to automatically fix the linting using the followi
     $ tox -e fix
     
 .. warning::     
-    Always check the results of ``tox -e fix`` before submitting as it is possible that the suggested changes may alter the code in 
-    an unintended way.
+    Always check the results of ``tox -e fix`` before submitting as the proposed changes may not always be the most optimal solution.
 
 Testing documentation
 ~~~~~~~~~~~~~~~~~~~~~
@@ -82,9 +81,9 @@ You can generate the API documentation in HTML format using ``tox`` for viewing 
 
 .. code-block:: console
 
-    $ tox -e FIXME
+    $ tox -e docsbuild
 
-This will create the `FIXME build` directory with the generated documentation in HTML format.
+This will create the `tests/docs./build/html` directory with the generated documentation in HTML format.
 Apart from the styling, this will show you how your documentation will appear 
 on https://docs.dissect.tools if your changes are accepted.
 
@@ -96,14 +95,7 @@ After the build process has finished, you can view the documentation in, for exa
 
 .. code-block:: console
      
-     $ firefox build/html/index.html
-
-
-If you experience build issues, you can clean up your environment using:
-
-.. code-block:: console
-    
-    $ make clean FIXME
+     $ firefox tests/docs/build/html/index.html
 
 
 Checking external URLs
@@ -116,11 +108,11 @@ You can check for broken links by invoking the following command:
 
 .. code-block:: console
 
-    $ tox -e FIXME linkcheck
+    $ tox -e docslinkcheck
 
 
 You will see the results of the checks in your terminal, but they can also be found in the file 
-`FIXME build/linkcheck/output.txt`.
+``tests/docs/build/linkcheck/output.txt``.
 
 Understanding linkcheck output
 """"""""""""""""""""""""""""""  

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,10 +35,7 @@ The easiest way to get started is to install the latest version of all Dissect p
 It is recommended that you use a `virtual environment <https://docs.python.org/3/tutorial/venv.html>`_.
 
 .. note ::
-
-    Dissect is built and tested against Python 3.9 (CPython and PyPy). Older versions may not work, as
-    features are used which may not yet be supported by these versions. Newer versions will probably work, but are not
-    guaranteed to.
+    .. include:: /versions.rst
 
 To quickly get familiar with Dissect, read on to :doc:`/usage/introduction`. If you're interested in what makes it
 tick, continue reading at :doc:`/overview/index`.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -121,6 +121,7 @@ For more information about what Dissect is and how it works, read on at :doc:`/o
 
     /contributing/developing
     /contributing/style-guide
+    /contributing/tooling
     License </license>
 
 .. toctree::

--- a/docs/source/versions.rst
+++ b/docs/source/versions.rst
@@ -1,0 +1,8 @@
+Dissect is built and tested for the following Python versions:
+
+- CPython 3.9, 3.10 and 3.11.
+- PyPy 3.9.
+
+Older versions than specified may not work, as some features are not supported by these versions.
+
+Newer versions will probably work, but are not guaranteed to.


### PR DESCRIPTION
The 'Contributing' section is separated in three parts, discussing process, style guide and tooling.

'Developing for Dissect' now describes the contributing process in more detail, including the Contributor License Agreement and principle of least dependencies.

'Style guide' has been reworded for clarity and provided with extra headings to better discern the different topics.

'Tooling' now includes information about tooling that was under a different section previously and also adds information in the upcoming tooling to test documentation.