### PR TITLE
Fix typo

### DIFF
--- a/docs/source/usage/use-cases.rst
+++ b/docs/source/usage/use-cases.rst
@@ -24,7 +24,7 @@ argument, while using the basic OS functions. You can write this to a csv file t
 
 .. code-block:: console
 
-    $ target-query targets/ -f hostname,domain,OS,version,ips --cmdb -d ";" > docs/CMDB.csv
+    $ target-query targets/ -f hostname,domain,os,version,ips --cmdb -d ";" > docs/CMDB.csv
 
 Pushing query results to a search platform
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
`target-query: error: argument -f/--function contains invalid plugin(s): OS`