### PR TITLE
Fail building if Sphinx generates warnings

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= -jauto
+SPHINXOPTS    ?= -jauto -w $(BUILDDIR)/warnings.log --fail-on-warning
 SPHINXBUILD   ?= sphinx-build
 SPHINXWATCH   ?= sphinx-autobuild
 SOURCEDIR     = source

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -164,3 +164,8 @@ copybutton_line_continuation_character = "\\"
 copybutton_here_doc_delimiter = "EOT"
 copybutton_selector = "div:not(.no-copybutton) > div.highlight > pre"
 copybutton_exclude = ".linenos"
+
+suppress_warnings = [
+    # https://github.com/readthedocs/sphinx-autoapi/issues/285
+    "autoapi.python_import_resolution",
+]


### PR DESCRIPTION
Currently `make build` will continue if it encounters invalid rst. We believe it should fail. To accommodate a possible future GitHub CI pipeline we save these warnings to `warnings.log` just like we do in `dissect.target`.