### PR TITLE
Fix more Sphinx warnings

### DIFF
--- a/docs/source/_ext/dissect_plugins.py
+++ b/docs/source/_ext/dissect_plugins.py
@@ -124,7 +124,7 @@ def _format_template(name: str, plugins: list[dict]) -> str:
                 exports="\n".join(
                     f"- :doc:`/plugins/{ns}.{export}`"
                     for export in plugin.exports
-                    if export != "get_all_records"
+                    if export not in ["get_all_records", "__call__"]
                 )
             )
         else:

--- a/docs/source/_ext/dissect_plugins.py
+++ b/docs/source/_ext/dissect_plugins.py
@@ -66,7 +66,7 @@ def builder_inited(app: Sphinx) -> None:
             plugin_map.setdefault(ns, []).append(plugin)
 
         for export in plugin.exports:
-            if export in ["get_all_records", "__call__"]:  # TODO we need to remove this
+            if export == "__call__":
                 continue
 
             if ns:
@@ -124,7 +124,7 @@ def _format_template(name: str, plugins: list[dict]) -> str:
                 exports="\n".join(
                     f"- :doc:`/plugins/{ns}.{export}`"
                     for export in plugin.exports
-                    if export not in ["get_all_records", "__call__"]
+                    if export != "__call__"
                 )
             )
         else:

--- a/docs/source/_ext/dissect_plugins.py
+++ b/docs/source/_ext/dissect_plugins.py
@@ -66,7 +66,7 @@ def builder_inited(app: Sphinx) -> None:
             plugin_map.setdefault(ns, []).append(plugin)
 
         for export in plugin.exports:
-            if export == "get_all_records":  # TODO we need to remove this
+            if export in ["get_all_records", "__call__"]:  # TODO we need to remove this
                 continue
 
             if ns:

--- a/docs/source/acquire.rst
+++ b/docs/source/acquire.rst
@@ -14,8 +14,10 @@ To run **acquire** on a live system:
 
     To be able to access the full system to collect all its artefacts one must
     run acquire with administrator privileges.
+
 Output
-~~~~~~~~
+~~~~~~
+
 By default, an acquire operation will result in 3 files:
 
     - a log file (the contents of this file will also appear on the screen)
@@ -32,7 +34,6 @@ You can feed the resulting tar to tools like :doc:`target-query <tools/target-qu
 
 Profiles
 ~~~~~~~~
-
 
 By design, Acquire runs with the ``default`` profile,
 providing a curated selection of artifacts that aims to fulfill the

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -5,6 +5,6 @@ API Reference
     :maxdepth: 1
     :glob:
 
-    /api/acquire/index
+    /api/acquire/*/index
     /api/dissect/*/index
     /api/flow/*/index

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -168,4 +168,6 @@ copybutton_exclude = ".linenos"
 suppress_warnings = [
     # https://github.com/readthedocs/sphinx-autoapi/issues/285
     "autoapi.python_import_resolution",
+    # https://github.com/sphinx-doc/sphinx/issues/4961
+    "ref.python",
 ]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -110,7 +110,6 @@ Get in touch, join us on `github <https://github.com/fox-it/dissect.target>`_!
     /usage/index
     /plugins/index
     Architecture </overview/index>
-    /projects/index
     /advanced/index
     /api/index
 

--- a/docs/source/projects/dissect.util/index.rst
+++ b/docs/source/projects/dissect.util/index.rst
@@ -29,6 +29,7 @@ the faster, native (C-based) lz4 and lzo implementations in other dissect projec
 lzo extras:
 
 .. code-block:: console
+
     $ pip install "dissect.util[lz4,lzo]"
 
 Unfortunately there is no binary ``python-lzo`` wheel for PyPy installations on Windows, so it won't install there.

--- a/docs/source/rdump.rst
+++ b/docs/source/rdump.rst
@@ -1,5 +1,6 @@
 rdump
 -----
+
 `rdump` is used to process, filter and format target-query results.
 By default, target-query generates records. Records in this sense are binary representations of parsed artefacts.
 They are transformed to text by the default mechanism. An example is given below:
@@ -108,8 +109,9 @@ Instead of having to design your own format you can also choose one of these per
 * JSON (``-j`` or ``--mode=json``)
 * CSV (``-C`` or ``--mode=csv``)
 * Line (``-L`` or ``--mode=line``)
+
 Adapter Formatting
-~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 It is also possible to let an adapter take care of the formatting. For instance, if you wish to have your
 records in an archive format with a year-month-day folder structure, you can employ the ``-w`` option and
 choose the archive adapter: ``archive://outputdir``. For complete list of adapters use ``-a``.

--- a/docs/source/tools/acquire.rst
+++ b/docs/source/tools/acquire.rst
@@ -126,7 +126,7 @@ such as `PyOxidizer <https://pyoxidizer.readthedocs.io/en/stable/>`_ and `PyInst
 Unfortunately, however, neither support cross platform executable creation.
 
 PyOxidizer
-~~~~~~~~~~
+^^^^^^^^^^
 
 PyOxidizer is a relatively new Python application packer that integrates heavily with Rust. It has a lot of exciting options
 and functionality, at the cost of a fairly large executable size and complex configuration options.
@@ -160,7 +160,7 @@ This is just a very basic example. There are a lot more settings to tweak and op
 as an exercise to the reader.
 
 PyInstaller
-~~~~~~~~~~~
+^^^^^^^^^^^
 
 PyInstaller has been around for a long time and can be considered the de facto utility for packaging Python into
 executables, for both legitimate and malicious purposes. It has a lot less options to play with than PyOxidizer, but

--- a/docs/source/usage/disk-encryption.rst
+++ b/docs/source/usage/disk-encryption.rst
@@ -6,7 +6,7 @@ all Dissect tools will be able to work transparently on the source data, without
 of the source data.
 
 For more information about supported full disk encryption implementations and API usage see 
-the :ref:`projects/dissect.fve` project.
+the :doc:`/projects/dissect.fve/index` project.
 
 Keychains
 ---------

--- a/docs/source/usage/first-steps/index.rst
+++ b/docs/source/usage/first-steps/index.rst
@@ -20,18 +20,17 @@ an MSEdge Windows VM. These VM images were obtained from
 
 Our investigation material consists of:
 
-* ``SCHARDT.001`` (DD image, `mirror <https://files.dissect.tools/images/SCHARDT.001>`_, 636 MB)
-* ``SCHARDT.002`` (DD image, `mirror <https://files.dissect.tools/images/SCHARDT.002>`_, 636 MB)
-* ``SCHARDT.003`` (DD image, `mirror <https://files.dissect.tools/images/SCHARDT.003>`_, 636 MB)
-* ``SCHARDT.004`` (DD image, `mirror <https://files.dissect.tools/images/SCHARDT.004>`_, 636 MB)
-* ``SCHARDT.005`` (DD image, `mirror <https://files.dissect.tools/images/SCHARDT.005>`_, 636 MB)
-* ``SCHARDT.006`` (DD image, `mirror <https://files.dissect.tools/images/SCHARDT.006>`_, 636 MB)
-* ``SCHARDT.007`` (DD image, `mirror <https://files.dissect.tools/images/SCHARDT.007>`_, 636 MB)
-* ``SCHARDT.008`` (DD image, `mirror <https://files.dissect.tools/images/SCHARDT.008>`_, 199 MB)
-* ``4Dell Latitude CPi.E01`` (EnCase image, `mirror <https://files.dissect.tools/images/4Dell+Latitude+CPi.E01>`_, 641 MB)
-* ``4Dell Latitude CPi.E02`` (EnCase image, `mirror <https://files.dissect.tools/images/4Dell+Latitude+CPi.E02>`_, 400 MB)
-* ``IE11-Win81-VMWare-disk1.vmdk`` (Full VMDK file, `mirror <https://files.dissect.tools/images/IE11-Win81-VMWare-disk1.vmdk>`_, 8.0 GB)
-* ``MSEDGEWIN10_20220708124036.tar``  (``acquire`` container, `mirror <https://files.dissect.tools/images/MSEDGEWIN10_20220708124036.tar>`_, 469 MB)
+* `SCHARDT.001 <https://files.dissect.tools/images/SCHARDT.001>`_ (raw image, 636 MB)
+* `SCHARDT.002 <https://files.dissect.tools/images/SCHARDT.002>`_ (raw image, 636 MB)
+* `SCHARDT.004 <https://files.dissect.tools/images/SCHARDT.004>`_ (raw image, 636 MB)
+* `SCHARDT.005 <https://files.dissect.tools/images/SCHARDT.005>`_ (raw image, 636 MB)
+* `SCHARDT.006 <https://files.dissect.tools/images/SCHARDT.006>`_ (raw image, 636 MB)
+* `SCHARDT.007 <https://files.dissect.tools/images/SCHARDT.007>`_ (raw image, 636 MB)
+* `SCHARDT.008 <https://files.dissect.tools/images/SCHARDT.008>`_ (raw image, 199 MB)
+* `4Dell Latitude CPi.E01 <https://files.dissect.tools/images/4Dell+Latitude+CPi.E01>`_ (EnCase image, 641 MB)
+* `4Dell Latitude CPi.E02 <https://files.dissect.tools/images/4Dell+Latitude+CPi.E02>`_ (EnCase image, 400 MB)
+* `IE11-Win81-VMWare-disk1.vmdk <https://files.dissect.tools/images/IE11-Win81-VMWare-disk1.vmdk>`_ (Full VMDK file, 8.0 GB)
+* `MSEDGEWIN10_20220708124036.tar <https://files.dissect.tools/images/MSEDGEWIN10_20220708124036.tar>`_ (``acquire`` container, 469 MB)
 
 While Dissect will work fine under Windows, a Unix based system is assumed when following along with these first steps.
 

--- a/docs/source/usage/introduction.rst
+++ b/docs/source/usage/introduction.rst
@@ -1,7 +1,7 @@
 Introduction
 ============
 
-After installing Dissect by following the :ref:`installation steps <index:Getting Started>`, the Dissect
+After installing Dissect by following the :ref:`installation steps <install/index>`, the Dissect
 tools should be available to you.
 
 To verify if the tooling is available, start by typing ``target-`` in your command line interface and press your

--- a/docs/source/usage/introduction.rst
+++ b/docs/source/usage/introduction.rst
@@ -1,7 +1,7 @@
 Introduction
 ============
 
-After installing Dissect by following the :ref:`installation steps <install/index>`, the Dissect
+After installing Dissect by following the :doc:`installation steps </install>`, the Dissect
 tools should be available to you.
 
 To verify if the tooling is available, start by typing ``target-`` in your command line interface and press your


### PR DESCRIPTION
That was a bit too quick :smile: 

With this additional suppressed warning the docs only generate ~70 warnings, which should be fixed in `.rst` files and/or project specific docstrings:

```
/tmp/dissect-docs/docs/source/api/dissect/shellitem/lnk/index.rst:97: WARNING: duplicate object description of dissect.shellitem.lnk.c_lnk, other instance in api/dissect/shellitem/lnk/c_lnk/index, use :no-index: for one of them
/tmp/dissect-docs/docs/source/api/dissect/sql/utils/index.rst:23:<autosummary>:1: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/sql/utils/index.rst:26: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/sql/utils/index.rst:26: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/tmp/dissect-docs/docs/source/acquire.rst:17: WARNING: Explicit markup ends without a blank line; unexpected unindent. [docutils]
/tmp/dissect-docs/docs/source/api/acquire/acquire/collector/index.rst:279: ERROR: Unexpected indentation. [docutils]
/tmp/dissect-docs/docs/source/api/acquire/acquire/gui/win32/index.rst:246: WARNING: duplicate object description of acquire.acquire.gui.win32.WHITE_BRUSH, other instance in api/acquire/acquire/gui/win32/index, use :no-index: for one of them
/tmp/dissect-docs/docs/source/api/acquire/acquire/hashes/index.rst:119: ERROR: Unexpected indentation. [docutils]
/tmp/dissect-docs/docs/source/api/acquire/acquire/hashes/index.rst:122: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/btrfs/c_btrfs/index.rst:902: WARNING: duplicate object description of dissect.btrfs.c_btrfs.BTRFS_BLOCK_GROUP_TYPE_MASK, other instance in api/dissect/btrfs/c_btrfs/index, use :no-index: for one of them
/tmp/dissect-docs/docs/source/api/dissect/cim/classes/index.rst:360: ERROR: Unexpected indentation. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/cim/classes/index.rst:361: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/cim/classes/index.rst:364: ERROR: Unexpected indentation. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/cim/classes/index.rst:365: WARNING: Inline strong start-string without end-string. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/cstruct/index.rst:425: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/cstruct/index.rst:431: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/cstruct/index.rst:499: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/cstruct/index.rst:505: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/cstruct/types/enum/index.rst:116: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/cstruct/types/enum/index.rst:122: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/cstruct/types/flag/index.rst:38: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/cstruct/types/flag/index.rst:44: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/cstruct/types/index.rst:269: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/cstruct/types/index.rst:275: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/cstruct/types/index.rst:320: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/cstruct/types/index.rst:326: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/etl/headers/system/index.rst:79: ERROR: Unexpected indentation. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/etl/headers/system/index.rst:124: ERROR: Unexpected indentation. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/eventlog/utils/index.rst:27: ERROR: Unexpected indentation. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/eventlog/utils/index.rst:28: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/eventlog/utils/index.rst:31: ERROR: Unexpected indentation. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/eventlog/utils/index.rst:32: WARNING: Inline strong start-string without end-string. [docutils]
/tmp/dissect-docs/docs/source/rdump.rst:111: WARNING: Bullet list ends without a blank line; unexpected unindent. [docutils]
/tmp/dissect-docs/docs/source/rdump.rst:112: WARNING: Title underline too short.

Adapter Formatting
~~~~~~~~~~~~ [docutils]
/tmp/dissect-docs/docs/source/rdump.rst:112: WARNING: Title underline too short.

Adapter Formatting
~~~~~~~~~~~~ [docutils]
/tmp/dissect-docs/docs/source/tools/acquire.rst:128: CRITICAL: Title level inconsistent:

PyOxidizer
~~~~~~~~~~ [docutils]
/tmp/dissect-docs/docs/source/tools/acquire.rst:162: CRITICAL: Title level inconsistent:

PyInstaller
~~~~~~~~~~~ [docutils]
/tmp/dissect-docs/docs/source/usage/first-steps/index.rst:2: WARNING: Duplicate explicit target name: "mirror". [docutils]
/tmp/dissect-docs/docs/source/usage/first-steps/index.rst:2: WARNING: Duplicate explicit target name: "mirror". [docutils]
/tmp/dissect-docs/docs/source/usage/first-steps/index.rst:2: WARNING: Duplicate explicit target name: "mirror". [docutils]
/tmp/dissect-docs/docs/source/usage/first-steps/index.rst:2: WARNING: Duplicate explicit target name: "mirror". [docutils]
/tmp/dissect-docs/docs/source/usage/first-steps/index.rst:2: WARNING: Duplicate explicit target name: "mirror". [docutils]
/tmp/dissect-docs/docs/source/usage/first-steps/index.rst:2: WARNING: Duplicate explicit target name: "mirror". [docutils]
/tmp/dissect-docs/docs/source/usage/first-steps/index.rst:2: WARNING: Duplicate explicit target name: "mirror". [docutils]
/tmp/dissect-docs/docs/source/usage/first-steps/index.rst:2: WARNING: Duplicate explicit target name: "mirror". [docutils]
/tmp/dissect-docs/docs/source/usage/first-steps/index.rst:2: WARNING: Duplicate explicit target name: "mirror". [docutils]
/tmp/dissect-docs/docs/source/usage/first-steps/index.rst:2: WARNING: Duplicate explicit target name: "mirror". [docutils]
/tmp/dissect-docs/docs/source/usage/first-steps/index.rst:2: WARNING: Duplicate explicit target name: "mirror". [docutils]
/tmp/dissect-docs/docs/source/projects/dissect.util/index.rst:31: ERROR: Error in "code-block" directive:
maximum 1 argument(s) allowed, 5 supplied.

.. code-block:: console
    $ pip install "dissect.util[lz4,lzo]" [docutils]
/tmp/dissect-docs/docs/source/api/flow/record/stream/index.rst:4: WARNING: duplicate object description of flow.record.stream, other instance in api/flow/record/index, use :no-index: for one of them
/tmp/dissect-docs/docs/source/api/index.rst:4: WARNING: toctree contains reference to nonexisting document 'api/acquire/index' [toc.not_readable]
/tmp/dissect-docs/docs/source/index.rst:104: WARNING: duplicated entry found in toctree: projects/index
/tmp/dissect-docs/docs/source/api/dissect/volume/vinum/config/index.rst:374: ERROR: Unexpected indentation. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/volume/vinum/config/index.rst:375: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/volume/vinum/config/index.rst:378: ERROR: Unexpected indentation. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/volume/vinum/config/index.rst:379: WARNING: Inline strong start-string without end-string. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/volume/vinum/vinum/index.rst:87: ERROR: Unexpected indentation. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/volume/vinum/vinum/index.rst:88: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/volume/vinum/vinum/index.rst:91: ERROR: Unexpected indentation. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/volume/vinum/vinum/index.rst:92: WARNING: Inline strong start-string without end-string. [docutils]
/tmp/dissect-docs/docs/source/api/flow/record/adapter/text/index.rst:61: ERROR: Unexpected indentation. [docutils]
/tmp/dissect-docs/docs/source/api/flow/record/adapter/text/index.rst:62: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/tmp/dissect-docs/docs/source/api/flow/record/adapter/text/index.rst:65: ERROR: Unexpected indentation. [docutils]
/tmp/dissect-docs/docs/source/api/flow/record/adapter/text/index.rst:66: WARNING: Inline strong start-string without end-string. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/target/tools/utils/index.rst:31:<autosummary>:1: WARNING: Inline literal start-string without end-string. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/target/tools/utils/index.rst:38: WARNING: Inline literal start-string without end-string. [docutils]
/tmp/dissect-docs/docs/source/api/dissect/util/compression/lz4/index.rst:4: WARNING: duplicate object description of dissect.util.compression.lz4, other instance in api/dissect/util/compression/index, use :no-index: for one of them
/tmp/dissect-docs/docs/source/api/dissect/util/compression/lzo/index.rst:4: WARNING: duplicate object description of dissect.util.compression.lzo, other instance in api/dissect/util/compression/index, use :no-index: for one of them
/tmp/dissect-docs/docs/source/api/acquire/acquire/index.rst: WARNING: document isn't included in any toctree
/tmp/dissect-docs/docs/source/api/dissect/target/plugins/apps/productivity/msoffice/index.rst: WARNING: document isn't included in any toctree
/tmp/dissect-docs/docs/source/usage/disk-encryption.rst:8: WARNING: undefined label: 'projects/dissect.fve' [ref.ref]
/tmp/dissect-docs/docs/source/usage/introduction.rst:4: WARNING: undefined label: 'index:getting started' [ref.ref]

```