### PR TITLE
Resolve duplicate object description warnings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -186,6 +186,21 @@ def autoapi_skip_hook(app: Sphinx, what: str, name: str, obj, skip: bool, option
     # Do not skip OS modules in dissect.target (caught by `private-members`)
     if name.endswith("._os") and what == "module":
         skip = False
+
+    # These entries have the issue that certain module or classes get exposed by __all__, however, this shadows a module
+    # that uses the same name, so we ignore them for now
+    if (
+        name
+        in [
+            "dissect.qnxfs.c_qnx4",
+            "dissect.qnxfs.c_qnx6",
+            "dissect.cstruct.cstruct",
+            "flow.record.stream",
+            "dissect.shellitem.lnk.c_lnk",
+        ]
+        and what != "module"
+    ):
+        skip = True
     return skip
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,6 +28,7 @@ sys.path.append(os.path.abspath("./_ext"))
 
 project = "Dissect"
 copyright = "2023, Fox-IT part of NCC Group"
+copyright = "2025, Fox-IT part of NCC Group"
 author = "Fox-IT part of NCC Group"
 
 # The full version, including alpha/beta/rc tags


### PR DESCRIPTION
There is an issue with sphinx generating warnings due to duplicate object entries

From what I found out, it only occurs in dissect-docs, this is not an issue when using docs-build
in other projects.

What I think the issue might be is that this issue occurs due to shadowing of modules, and sphinx not knowing how or what.
For example, with the following construction:

```
dissect.cstruct:
   __init__.py:
     from dissect.cstruct.cstruct import cstruct
     __all__ = ["cstruct"]
   cstruct.py:
     class cstruct: ...
```

Sphinx sees both `dissect.cstruct.__init__.cstruct` and `dissect.cstruct.cstruct` as conflicting/duplicate object entries.
I assume this happens because the one in the `__init__.py` file shadows the module `cstruct` in the same directory.

My current fix is skip generating rst for the cstruct class inside `api/dissect/cstruct/index` and only render it in `api/dissect/cstruct/cstruct/index`.

An alternative method is avoid generating class definitions exposed by `__init__.__all__` at all inside `api/dissect/cstruct/index` this would remove all those classes below `Functions`.
